### PR TITLE
use Camelcase firts char UPPER and rest lower for model crud, CI3 naming convention

### DIFF
--- a/application/libraries/Grocery_CRUD_Multiuploader.php
+++ b/application/libraries/Grocery_CRUD_Multiuploader.php
@@ -84,8 +84,8 @@ class Grocery_CRUD_Multiuploader extends grocery_CRUD
 	{
 		parent::__construct();
 		$this->ci = &get_instance();
-		$this->ci->load->model('grocery_CRUD_Model');
-		$this->basic_model = new grocery_CRUD_Model();
+		$this->ci->load->model('Grocery_crud_model');
+		$this->basic_model = new Grocery_crud_model();
 		log_message('debug', "Grocery_CRUD_Multiuploader Class Initialized.");
 	}
 	


### PR DESCRIPTION
use Camelcase firts char UPPER and rest lower for model crud, CI3 naming convention

* when instance the model of grocerycrud, firts char UPPER and rest lower
* for model crud, CI3 naming convention said that except first, all must be lowercase
* in really, all the loading must be case-sensitive
* this still are compatible with CI2 (if the model are names exactly as invoked, firts char UPPER and rest lower)